### PR TITLE
Fix Node hashing so DCE demo runs

### DIFF
--- a/graphlet/graph.py
+++ b/graphlet/graph.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import List, Dict, Any
 
-@dataclass
+@dataclass(eq=False)
 class Node:
     op: str
     inputs: List["Node"] = field(default_factory=list)


### PR DESCRIPTION
## Summary
- make the Node dataclass rely on object identity for hashing so nodes can be stored in user sets

## Testing
- python -m examples.demo_dce

------
https://chatgpt.com/codex/tasks/task_e_68d379c11c44832482114f3039432610